### PR TITLE
Fix typos

### DIFF
--- a/src/components/DAOLore.tsx
+++ b/src/components/DAOLore.tsx
@@ -4,17 +4,17 @@ export const DAOLore = () => {
     <div>
       <h2>DAO Lore</h2>
       <p>
-        FemboyDAO started in January 2022, with the goal of creating a community for crypto femboy enthusaists and launching femboy-themed crypto projects,
+        FemboyDAO started in January 2022, with the goal of creating a community for crypto femboy enthusiasts and launching femboy-themed crypto projects,
         starting with a crowdfunded NFT collection.
       </p>
       <h3>The Crowdfund</h3>
       <p>
-        In April 2022 the DAO crowdfunded 71.2 ETH to support the launch of the NFT collection and future projects.
-        Shortly afterwards a collection of 9 active and responsible looking DAO members formed a council, which is taking charge of the DAOs goals.
+        In April 2022, the DAO crowdfunded 71.2 ETH to support the launch of the NFT collection and future projects.
+        Shortly afterwards, a collection of 9 active and responsible looking DAO members formed a council, which is taking charge of the DAO's goals.
       </p>
       <h3>Main NFT Collection</h3>
       <p>
-        Work on the main collection started in July 2022 after the council found a worthy artist to draw it, Nekobox. 
+        Work on the main collection started in July 2022 after the council found a worthy artist to draw it: Nekobox. 
         This collection is still in development, so check again later. 
       </p>
       <h3>Scuffed Femboys</h3>


### PR DESCRIPTION
"Enthusiasts" and "the DAO's goals" were misspelled. The other changes are preferential.  
I'd also prefer to add a link to Nekobox's linktree, but I'm not sure how you'd want to encode a link in this thing.