### PR TITLE
small visual fix

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -672,3 +672,8 @@ p.error-message {
 .container-status h1 {
   font-size: 23px;
 }
+
+/* Wallet Connect WalletConnect - small fix on firefox where this div adds a few pixels to the bottom of the page */
+.-walletlink-css-reset .-walletlink-link-flow-root {
+  display:block;
+}


### PR DESCRIPTION
Firefox had a ~4 pixel space at the bottom
the wallet-connect component in its disabled form was rogue